### PR TITLE
Make tests pass

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,7 @@ env:
   - distro: ubuntu1404
   - distro: debian8
   - distro: debian9
+  - distro: debian10
 
 
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ env:
   - distro: centos7
   - distro: ubuntu1804
   - distro: ubuntu1604
-  - distro: ubuntu1404
   - distro: debian8
   - distro: debian9
   - distro: debian10

--- a/README.md
+++ b/README.md
@@ -111,7 +111,7 @@ The virtual path for the RabbitMQ server.
             password: "{{ db_server_pass }}"
 
         rabbitmq_users:
-        - user: "{{ rabbitmq_server_user }}"
+        - name: "{{ rabbitmq_server_user }}"
             password: "{{ rabbitmq_server_pass }}"
             vhost: "{{ rabbitmq_server_vpath }}"
             configure_priv: .*
@@ -125,7 +125,7 @@ The virtual path for the RabbitMQ server.
 
     roles:
         - geerlingguy.postgresql
-        - Stouts.rabbitmq
+        - mrlesmithjr.rabbitmq
         - geerlingguy.redis
         - geerlingguy.nodejs
         - ONLYOFFICE.documentserver

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -3,6 +3,6 @@
       name: "{{ item }}"
       state: restarted
     with_items:
-    - 'onlyoffice-documentserver:converter'
-    - 'onlyoffice-documentserver:docservice'
+    - 'ds:converter'
+    - 'ds:docservice'
     become: yes

--- a/tests/requirements.yml
+++ b/tests/requirements.yml
@@ -4,4 +4,4 @@
 
 - src: geerlingguy.postgresql
 
-- src: Stouts.rabbitmq
+- src: mrlesmithjr.rabbitmq

--- a/tests/test.yml
+++ b/tests/test.yml
@@ -43,7 +43,7 @@
         password: "{{ db_server_pass }}"
 
     rabbitmq_users:
-      - user: "{{ rabbitmq_server_user }}"
+      - name: "{{ rabbitmq_server_user }}"
         password: "{{ rabbitmq_server_pass }}"
         vhost: "{{ rabbitmq_server_vpath }}"
         configure_priv: .*
@@ -52,6 +52,7 @@
         tags: administrator
 
     rabbitmq_users_remove: []
+    rabbitmq_debian_version: 3.7.23-1
 
     redis_bind_interface: 0.0.0.0
 
@@ -62,7 +63,7 @@
 
   roles:
     - geerlingguy.postgresql
-    - Stouts.rabbitmq
+    - mrlesmithjr.rabbitmq
     - geerlingguy.redis
     - geerlingguy.nodejs
     - role_under_test

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -2,7 +2,7 @@ debian_repo: "deb http://deb.debian.org/debian {{ ansible_distribution_release }
 package_repo: "deb http://download.onlyoffice.com/repo/debian squeeze main"
 
 onlyoffice_default_config: /etc/onlyoffice/documentserver/local.json
-json: json -q -f {{ onlyoffice_default_config }}
+json: /var/www/onlyoffice/documentserver/npm/json -q -f {{ onlyoffice_default_config }}
 
 filestorage_mount_path: /var/lib/onlyoffice/documentserver/App_Data/cache/files
 fonts_mount_path: /usr/share/fonts


### PR DESCRIPTION
* Drop support for Ubuntu 14.04, it's end-of-life
* Add suport for Debian 10
* Drop json commands. They are already part of the Debian package.
* Adjust supervisor group name (Fix #11)
* Replace rabbitmq role with one that is maintained