### PR TITLE
add the option to copy only certs path

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,10 @@ The virtual path for the RabbitMQ server.
 
 The option to add ssl configuration or not.
 
+    copy_certs: false
+
+The option to copy the certificates or their path.
+
     key_file: "~/certs/tls.key"
 
 The path to the key file.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,3 +19,6 @@ key_file: "~/certs/tls.key"
 cert_file: "~/certs/tls.crt"
 cluster_mode: false
 start_example: false
+
+#extra_files:
+#  - {url: example.org/download, dest: /var/www/onlyoffice/documentserver, mode: 644}

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -14,6 +14,7 @@ rabbitmq_server_pass: guest
 rabbitmq_server_vpath: /
 
 enable_ssl: false
+copy_certs: false
 key_file: "~/certs/tls.key"
 cert_file: "~/certs/tls.crt"
 cluster_mode: false

--- a/tasks/extra_config.yml
+++ b/tasks/extra_config.yml
@@ -1,0 +1,10 @@
+---
+
+- name: Download extra files from url
+  get_url:
+    url: "{{ item.url }}"
+    dest: "{{ item.dest }}"
+    mode: "{{ item.mode }}"
+    owner: "{{ item.owner }}"
+    group: "{{ item.group }}"
+  with_items: "{{ extra_files }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,3 +30,7 @@
     group: root
     mode: 0644
   when: onlyoffice_license is defined
+
+- name: Inlude extra files
+  include_tasks: extra_config.yml
+  when: extra_files is defined

--- a/tasks/ssl.yml
+++ b/tasks/ssl.yml
@@ -3,6 +3,7 @@
     file:
             path: "{{ certs_directory }}"
             state: directory
+    when: copy_certs == true
     become: yes
 
 
@@ -13,6 +14,7 @@
             owner: root
             group: root
             mode: "0400"
+    when: copy_certs == true
     become: yes
 
   - name: Copy certificate to server
@@ -21,24 +23,15 @@
             dest: "{{ certs_directory + 'tls.crt' }}"
             owner: root
             group: root
+    when: copy_certs == true
     become: yes
 
   - name: Copy ds.conf template
-    shell: cp -f /etc/onlyoffice/documentserver/nginx/ds-ssl.conf.tmpl "{{ nginx_config_path }}"
-    become: yes
-
-  - name: Edit ssl cert path
-    lineinfile:
-            path: "{{ nginx_config_path }}" 
-            regexp: "SSL_CERTIFICATE_PATH"
-            line: "  ssl_certificate {{ certs_directory + 'tls.crt' }};"
-    become: yes
-
-  - name: Edit ssl key path
-    lineinfile:
-            path: "{{ nginx_config_path }}" 
-            regexp: "SSL_KEY_PATH"
-            line: "  ssl_certificate_key {{ certs_directory + 'tls.key' }};"
+    template: 
+      src: etc/onlyoffice/documentserver/nginx/ds.conf.j2
+      dest: "{{ nginx_config_path }}"
+      owner: root
+      group: root
     notify: 
         restart-nginx
     become: yes

--- a/templates/etc/onlyoffice/documentserver/nginx/ds.conf.j2
+++ b/templates/etc/onlyoffice/documentserver/nginx/ds.conf.j2
@@ -1,0 +1,72 @@
+include /etc/nginx/includes/http-common.conf;
+
+## Normal HTTP host
+server {
+  listen 0.0.0.0:80;
+  listen [::]:80 default_server;
+  server_name _;
+  server_tokens off;
+
+  ## Redirects all traffic to the HTTPS host
+  root /nowhere; ## root doesn't have to be a valid path since we are redirecting
+  rewrite ^ https://$host$request_uri? permanent;
+}
+
+#HTTP host for internal services
+server {
+  listen 127.0.0.1:80;
+  listen [::1]:80;
+  server_name localhost;
+  server_tokens off;
+
+  include /etc/nginx/includes/ds-common.conf;
+  include /etc/nginx/includes/ds-docservice.conf;
+}
+
+## HTTPS host
+server {
+  listen 0.0.0.0:443 ssl;
+  listen [::]:443 ssl default_server;
+  server_tokens off;
+  root /usr/share/nginx/html;
+
+  ## Strong SSL Security
+  ## https://raymii.org/s/tutorials/Strong_SSL_Security_On_nginx.html
+  ssl on;
+  ssl_certificate {% if copy_certs == true %} {{ certs_directory + 'tls.crt' }} {% else %} {{ cert_file }}{% endif %};
+  ssl_certificate_key {% if copy_certs == true %} {{ certs_directory + 'tls.key' }} {% else %} {{ key_file }}{% endif %};
+  # Uncomment string below and specify the path to the file with the password if you use encrypted certificate key
+  # ssl_password_file SSL_PASSWORD_PATH;
+  ssl_verify_client off;
+
+  ssl_ciphers "EECDH+AESGCM:EDH+AESGCM:AES256+EECDH:AES256+EDH";
+
+  ssl_protocols  TLSv1 TLSv1.1 TLSv1.2;
+  ssl_session_cache  builtin:1000  shared:SSL:10m;
+
+  ssl_prefer_server_ciphers   on;
+
+  add_header Strict-Transport-Security max-age=31536000;
+  # add_header X-Frame-Options SAMEORIGIN;
+  add_header X-Content-Type-Options nosniff;
+
+  ## [Optional] If your certficate has OCSP, enable OCSP stapling to reduce the overhead and latency of running SSL.
+  ## Replace with your ssl_trusted_certificate. For more info see:
+  ## - https://medium.com/devops-programming/4445f4862461
+  ## - https://www.ruby-forum.com/topic/4419319
+  ## - https://www.digitalocean.com/community/tutorials/how-to-configure-ocsp-stapling-on-apache-and-nginx
+  # ssl_stapling on;
+  # ssl_stapling_verify on;
+  # ssl_trusted_certificate /etc/nginx/ssl/stapling.trusted.crt;
+  # resolver 208.67.222.222 208.67.222.220 valid=300s; # Can change to your DNS resolver if desired
+  # resolver_timeout 10s;
+
+  ## [Optional] Generate a stronger DHE parameter:
+  ##   cd /etc/ssl/certs
+  ##   sudo openssl dhparam -out dhparam.pem 4096
+  ##
+  # ssl_dhparam /etc/ssl/certs/dhparam.pem;
+
+  include /etc/nginx/includes/ds-*.conf;
+
+}

--- a/tests/test_ssl.yml
+++ b/tests/test_ssl.yml
@@ -53,6 +53,7 @@
     redis_bind_interface: 0.0.0.0
 
     enable_ssl: true
+    copy_certs: true
     key_file: "test.key"
     cert_file: "test.crt"
 


### PR DESCRIPTION
Hey guys, we work with [Certbot (for Let's Encrypt)](https://github.com/geerlingguy/ansible-role-certbot) and would like to copy only the path of the certificates inside the **nginx** `ds.conf` to automate everything.

I added a template for `ds.conf` as well to make it idempotent.

Thank you and tell me any questions or suggestions

Cheers!