### PR TITLE
Don't run task `Set up db user password` when in check mode

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -85,7 +85,9 @@
       question: onlyoffice/db-pwd
       value: "{{ db_server_pass }}"
       vtype: password
-    when: db_server_pass|length > 0
+    when:
+      - db_server_pass|length > 0
+      - not ansible_check_mode
     become: yes
 
   - name: Install documentserver


### PR DESCRIPTION
Setting passwords in Debconf always creates a change, which is annoying
when running the role in check mode in order to track real changes.
That's why it's better to don't run this particular task at all in check
mode.

This change makes the role idempotent at least in check mode.