### PR TITLE
CoAuthoring has no redis, we add it before adding properties

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -78,6 +78,11 @@
       state: latest
     become: yes
 
+  - name: Set up redis map
+    shell: "{{ json }} -I -e 'this.services.CoAuthoring.redis  = {}'"
+    when: redis_server_host != ""
+    notify: restart-ds
+
   - name: Set up redis host name
     shell: "{{ json }} -I -e 'this.services.CoAuthoring.redis.host  = \"{{ redis_server_host }}\"'"
     when: redis_server_host != ""


### PR DESCRIPTION
CoAuthoring has no 'redis'. We add it before adding properties. Tested on ubuntu 18.
