### PR TITLE
allow injecting arbitrary settings into local.json

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -176,6 +176,7 @@
     become: yes
 
   - name: "Configure {{ onlyoffice_default_config }}"
+    when: onlyoffice_local_json
     block:
       - name: "Read {{ onlyoffice_default_config }}"
         ansible.builtin.command: "cat {{ onlyoffice_default_config }}"
@@ -193,7 +194,6 @@
           dest: "{{ onlyoffice_default_config }}"
           content: "{{ current_onlyoffice_local_json | combine(onlyoffice_local_json, recursive=true) | to_nice_json(indent=2, sort_keys=false) }}\n"
         notify: Restart-ds
-    when: onlyoffice_local_json
 
   - name: Start example service
     community.general.supervisorctl:

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -193,6 +193,7 @@
         ansible.builtin.copy:
           dest: "{{ onlyoffice_default_config }}"
           content: "{{ current_onlyoffice_local_json | combine(onlyoffice_local_json, recursive=true) | to_nice_json(indent=2, sort_keys=false) }}\n"
+          mode: 0644
         notify: Restart-ds
 
   - name: Start example service

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -178,18 +178,18 @@
   - name: "configure {{ onlyoffice_default_config }} ..."
     block:
       - name: "read {{ onlyoffice_default_config }}"
-        command: "cat {{ onlyoffice_default_config }}"
+        ansible.builtin.command: "cat {{ onlyoffice_default_config }}"
         become: true
         check_mode: false
         changed_when: false
         register: _local_json
 
       - name: read json
-        set_fact:
+        ansible.builtin.set_fact:
           current_onlyoffice_local_json: "{{ _local_json.stdout | from_json }}"
 
       - name: "write {{ onlyoffice_default_config }}"
-        copy:
+        ansible.builtin.copy:
           dest: "{{ onlyoffice_default_config }}"
           content: "{{ current_onlyoffice_local_json | combine(onlyoffice_local_json, recursive=true) | to_nice_json(indent=2, sort_keys=false) }}\n"
         notify: restart-ds

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -175,26 +175,13 @@
       - jwt_enabled | bool
     become: yes
 
-  - name: "Configure {{ onlyoffice_default_config }}"
+  - name: "Configure {{ onlyoffice_local_json_config }}"
+    ansible.builtin.copy:
+      dest: "{{ onlyoffice_local_json_config }}"
+      content: "{{ onlyoffice_local_json | to_nice_json(indent=2, sort_keys=false) }}\n"
+      mode: 0644
     when: onlyoffice_local_json
-    block:
-      - name: "Read {{ onlyoffice_default_config }}"
-        ansible.builtin.command: "cat {{ onlyoffice_default_config }}"
-        become: true
-        check_mode: false
-        changed_when: false
-        register: _local_json
-
-      - name: Read json
-        ansible.builtin.set_fact:
-          current_onlyoffice_local_json: "{{ _local_json.stdout | from_json }}"
-
-      - name: "Write {{ onlyoffice_default_config }}"
-        ansible.builtin.copy:
-          dest: "{{ onlyoffice_default_config }}"
-          content: "{{ current_onlyoffice_local_json | combine(onlyoffice_local_json, recursive=true) | to_nice_json(indent=2, sort_keys=false) }}\n"
-          mode: 0644
-        notify: Restart-ds
+    notify: Restart-ds
 
   - name: Start example service
     community.general.supervisorctl:

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -175,6 +175,26 @@
       - jwt_enabled | bool
     become: yes
 
+  - name: "configure {{ onlyoffice_default_config }} ..."
+    block:
+      - name: "read {{ onlyoffice_default_config }}"
+        command: "cat {{ onlyoffice_default_config }}"
+        become: true
+        check_mode: false
+        changed_when: false
+        register: _local_json
+
+      - name: read json
+        set_fact:
+          current_onlyoffice_local_json: "{{ _local_json.stdout | from_json }}"
+
+      - name: "write {{ onlyoffice_default_config }}"
+        copy:
+          dest: "{{ onlyoffice_default_config }}"
+          content: "{{ current_onlyoffice_local_json | combine(onlyoffice_local_json, recursive=true) | to_nice_json(indent=2, sort_keys=false) }}\n"
+        notify: restart-ds
+    when: onlyoffice_local_json
+
   - name: Start example service
     community.general.supervisorctl:
       name: ds:example

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -175,7 +175,7 @@
       - jwt_enabled | bool
     become: yes
 
-  - name: "Configure {{ onlyoffice_default_config }} ..."
+  - name: "Configure {{ onlyoffice_default_config }}"
     block:
       - name: "Read {{ onlyoffice_default_config }}"
         ansible.builtin.command: "cat {{ onlyoffice_default_config }}"

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -175,24 +175,24 @@
       - jwt_enabled | bool
     become: yes
 
-  - name: "configure {{ onlyoffice_default_config }} ..."
+  - name: "Configure {{ onlyoffice_default_config }} ..."
     block:
-      - name: "read {{ onlyoffice_default_config }}"
+      - name: "Read {{ onlyoffice_default_config }}"
         ansible.builtin.command: "cat {{ onlyoffice_default_config }}"
         become: true
         check_mode: false
         changed_when: false
         register: _local_json
 
-      - name: read json
+      - name: Read json
         ansible.builtin.set_fact:
           current_onlyoffice_local_json: "{{ _local_json.stdout | from_json }}"
 
-      - name: "write {{ onlyoffice_default_config }}"
+      - name: "Write {{ onlyoffice_default_config }}"
         ansible.builtin.copy:
           dest: "{{ onlyoffice_default_config }}"
           content: "{{ current_onlyoffice_local_json | combine(onlyoffice_local_json, recursive=true) | to_nice_json(indent=2, sort_keys=false) }}\n"
-        notify: restart-ds
+        notify: Restart-ds
     when: onlyoffice_local_json
 
   - name: Start example service

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -4,6 +4,29 @@ package_repo: "deb http://download.onlyoffice.com/repo/debian squeeze main"
 onlyoffice_default_config: /etc/onlyoffice/documentserver/local.json
 json: /var/www/onlyoffice/documentserver/npm/json -q -f {{ onlyoffice_default_config }}
 
+# allow injecting settings into local.json
+onlyoffice_local_json: {}
+# example:
+# onlyoffice_local_json:
+#   services:
+#     CoAuthoring:
+#       requestDefaults:
+#         rejectUnauthorized: false
+#       token:
+#         enable:
+#           request:
+#             inbox: true
+#             outbox: true
+#           browser: true
+#       secret:
+#         inbox:
+#           string: xxyyzz
+#         outbox:
+#           string: xxyyzz
+#         session:
+#           string: xxyyzz
+
+
 filestorage_mount_path: /var/lib/onlyoffice/documentserver/App_Data/cache/files
 fonts_mount_path: /usr/share/fonts
 

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -2,12 +2,14 @@ debian_repo: "deb http://deb.debian.org/debian {{ ansible_distribution_release }
 package_repo: "deb http://download.onlyoffice.com/repo/debian squeeze main"
 
 onlyoffice_default_config: /etc/onlyoffice/documentserver/local.json
+# see: https://github.com/node-config/node-config/wiki/Configuration-Files#file-load-order
 onlyoffice_local_json_config: /etc/onlyoffice/documentserver/local-production-linux.json
 json: /var/www/onlyoffice/documentserver/npm/json -q -f {{ onlyoffice_default_config }}
 
 # settings for onlyoffice_local_json_config
 # will be transformed to json
 # attention, intended for experienced users only!
+# see: https://github.com/node-config/node-config/wiki/Configuration-Files#arrays-are-merged-by-replacement
 onlyoffice_local_json: {}
 # example:
 # onlyoffice_local_json:

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -2,9 +2,11 @@ debian_repo: "deb http://deb.debian.org/debian {{ ansible_distribution_release }
 package_repo: "deb http://download.onlyoffice.com/repo/debian squeeze main"
 
 onlyoffice_default_config: /etc/onlyoffice/documentserver/local.json
+onlyoffice_local_json_config: /etc/onlyoffice/documentserver/local-production-linux.json
 json: /var/www/onlyoffice/documentserver/npm/json -q -f {{ onlyoffice_default_config }}
 
-# allow injecting settings into local.json
+# settings for onlyoffice_local_json_config
+# will be transformed to json
 # attention, intended for experienced users only!
 onlyoffice_local_json: {}
 # example:

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -5,6 +5,7 @@ onlyoffice_default_config: /etc/onlyoffice/documentserver/local.json
 json: /var/www/onlyoffice/documentserver/npm/json -q -f {{ onlyoffice_default_config }}
 
 # allow injecting settings into local.json
+# attention, intended for experienced users only!
 onlyoffice_local_json: {}
 # example:
 # onlyoffice_local_json:


### PR DESCRIPTION
While playing around with the role, trying different setups in a test lab, I encountered the problem that I need to make some changes in the `local.json` file.
The PR #18 addresses a similar problem, but the template is limited to a fixed set of settings and requires updates if the upstream file changes.
The current approach allows optionally injecting arbitrary settings into the `local.json`.
Upstream changes in the `local.json` will be honored, as the configured settings in the `onlyoffice_local_json` var will be merged with the original settings from the existing `local.json` file.
The tasks are only executed if there are some settings configured in the `onlyoffice_local_json` var.
A example for the `onlyoffice_local_json`var is provided in the `vars/Debian.yml`file.
Caveats:
 * As the settings in `onlyoffice_local_json` are not validated, this might mess up the `local.json` and is intended for advanced usage only. But as the tasks are optional and require manual configuration, I think this is justifiable.
 * The task is limited to debian variants only.