### PR TITLE
Use `state: present` not `latest` when installing Debian package

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -94,7 +94,7 @@
     apt: 
       name: "{{ package_name }}"
       update_cache: yes
-      state: latest
+      state: present
     become: yes
 
   - name: Set up redis host name


### PR DESCRIPTION
This will improve idempotence of the role. Updates are usually installed
by apt, unattended-upgrades, etc. and not by Ansible roles.