### PR TITLE
Configurable package state

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,10 @@ The password set for the PostgreSQL account.
 
 The package name of the ONLYOFFICE Document Server.
 
+    package_state: latest | present
+
+The package state of the ONLYOFFICE Document Server. If set to latest (default), a upgrade will be performed!
+
     redis_server_host: localhost
 
 The IP address or the name of the host where the Redis server is running.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,6 +4,8 @@ db_server_user: onlyoffice
 db_server_pass: onlyoffice
 
 package_name: onlyoffice-documentserver
+# set this to 'present' in order to prevent upgrades
+package_state: latest
 
 redis_server_host: localhost
 redis_server_port: 6379

--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -94,7 +94,7 @@
     apt: 
       name: "{{ package_name }}"
       update_cache: yes
-      state: latest
+      state: "{{ package_state }}"
     become: yes
 
   - name: Set up redis host name

--- a/tasks/RedHat7.yml
+++ b/tasks/RedHat7.yml
@@ -21,5 +21,5 @@
     yum:
       name: "{{ package_name }}"
       update_cache: yes
-      state: latest
+      state: "{{ package_state }}"
     become: yes

--- a/tasks/RedHat8.yml
+++ b/tasks/RedHat8.yml
@@ -22,5 +22,5 @@
     dnf:
       name: "{{ package_name }}"
       update_cache: yes
-      state: latest
+      state: "{{ package_state }}"
     become: yes


### PR DESCRIPTION
Add the option to keep the currently installed onlyoffice-documentserver package and do not upgrade to the latest version
```yaml
package_state: latest
# package_state: present
```