### PR TITLE
Debian repos: use https instead of http transport

### DIFF
--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -1,5 +1,5 @@
-debian_repo: "deb http://deb.debian.org/debian {{ ansible_distribution_release }} contrib"
-package_repo: "deb http://download.onlyoffice.com/repo/debian squeeze main"
+debian_repo: "deb https://deb.debian.org/debian {{ ansible_distribution_release }} contrib"
+package_repo: "deb https://download.onlyoffice.com/repo/debian squeeze main"
 
 onlyoffice_default_config: /etc/onlyoffice/documentserver/local.json
 json: /var/www/onlyoffice/documentserver/npm/json -q -f {{ onlyoffice_default_config }}

--- a/vars/RedHat7.yml
+++ b/vars/RedHat7.yml
@@ -1,3 +1,3 @@
-onlyoffice_repo: "http://download.onlyoffice.com/repo/centos/main/noarch/onlyoffice-repo.noarch.rpm"
-nginx_repo: "http://nginx.org/packages/centos/7/noarch/RPMS/nginx-release-centos-7-0.el7.ngx.noarch.rpm"
+onlyoffice_repo: "https://download.onlyoffice.com/repo/centos/main/noarch/onlyoffice-repo.noarch.rpm"
+nginx_repo: "https://nginx.org/packages/centos/7/noarch/RPMS/nginx-release-centos-7-0.el7.ngx.noarch.rpm"
 msttcore_fonts: "https://downloads.sourceforge.net/project/mscorefonts2/rpms/msttcore-fonts-installer-2.6-1.noarch.rpm"

--- a/vars/RedHat8.yml
+++ b/vars/RedHat8.yml
@@ -1,3 +1,3 @@
-onlyoffice_repo: "http://download.onlyoffice.com/repo/centos/main/noarch/onlyoffice-repo.noarch.rpm"
+onlyoffice_repo: "https://download.onlyoffice.com/repo/centos/main/noarch/onlyoffice-repo.noarch.rpm"
 nginx_repo: "https://nginx.org/packages/rhel/8/x86_64/RPMS/nginx-1.18.0-1.el8.ngx.x86_64.rpm"
 msttcore_fonts: "https://downloads.sourceforge.net/project/mscorefonts2/rpms/msttcore-fonts-installer-2.6-1.noarch.rpm"


### PR DESCRIPTION
Thanks for the role!

With setting the Debian repo variables in ROLENAME/vars they are hard to overwrite (ansible variable precedence).
I really like to avoid unencrypted connections where I can and therefore would really like to see this playbook 
using https for the debian repos. Alternatively moving the repo vars to defaults/main.yml would be an option. 
Please let me know if you'd prefer the later.

Thanks a lot.
