### PR TITLE
debian prereq

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -1,4 +1,8 @@
 ---
+- name: Install prereq
+  ansible.builtin.apt:
+    name: "{{ prereq_packages }}"
+
 - name: "Check if gpg key port is ok (port 11371)"
   ansible.builtin.wait_for:
     host: keyserver.ubuntu.com

--- a/vars/Debian.yml
+++ b/vars/Debian.yml
@@ -10,3 +10,6 @@ fonts_mount_path: /usr/share/fonts
 
 psql: "PGPASSWORD={{ db_server_pass }} psql -q -h{{ db_server_host }} -U{{ db_server_user }} -w -d{{ db_server_name }}"
 createdb_sql: /var/www/onlyoffice/documentserver/server/schema/postgresql/createdb.sql
+
+prereq_packages:
+  - debconf-utils


### PR DESCRIPTION
fixes error:
```
Failed to find required executable "debconf-get-selections" in paths:
/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
```