### PR TITLE
improve task 'Create db if it not exist'

### DIFF
--- a/tasks/Debian.yml
+++ b/tasks/Debian.yml
@@ -150,7 +150,8 @@
 - name: Create db if it not exist
   ansible.builtin.shell: "{{ psql }} -f {{ createdb_sql }}"
   register: result
-  changed_when: result.rc != 0
+  failed_when: "'ERROR:' in result.stderr or result.rc > 0"
+  changed_when: result.stderr_lines | length == 0
   notify: restart-ds
 
 - name: Start example service


### PR DESCRIPTION
improve / fixed failed and changed status for psql 15

For example if the DBuser has insufficient rights (some defaults changed in Postgresql 15), the script will NOT fail (rc = 0) bit stderr will contain something like:
`ERROR:  permission denied for schema public`

Similar: if the DB/tables are created by the script, it will have no output.
If the tables are already present, it will issue a warning, thus we can consider this as `not changed`